### PR TITLE
Fix for PhpStorm 2017.3 EAP 173.3475: PhpCodeEditUtil::insertDocCommentBefore deprecation

### DIFF
--- a/src/com/thanosp/phpstorm/inheritdoc/InheritDocUtil.java
+++ b/src/com/thanosp/phpstorm/inheritdoc/InheritDocUtil.java
@@ -63,7 +63,7 @@ public class InheritDocUtil {
                         commentString
                 );
 
-                PhpCodeEditUtil.insertDocCommentBefore(phpNamedElement, comment);
+                PhpCodeEditUtil.insertDocCommentBeforeAndGetTextRange(phpNamedElement, comment);
 
             }
         }.execute();
@@ -131,7 +131,7 @@ public class InheritDocUtil {
                         commentString
                 );
 
-                PhpCodeEditUtil.insertDocCommentBefore(phpNamedElement, comment);
+                PhpCodeEditUtil.insertDocCommentBeforeAndGetTextRange(phpNamedElement, comment);
 
             }
         }.execute();


### PR DESCRIPTION
Since 173.3475 build (next EAP from the current date) `PhpCodeEditUtil::insertDocCommentBefore` will be deprecated in favor of `PhpCodeEditUtil.insertDocCommentBeforeAndGetTextRange`, which was introduced in the same build. So, to avoid deprecation it's suggested to change corresponding methods calls. In your use case new method will have the same behavior.

Could you please test the change and apply it?